### PR TITLE
potential buffer leak

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,10 @@ GLGeometry.prototype.faces = function faces(attr, opts) {
   attr = attr.cells ? attr.cells : attr
 
   this._dirty = true
+
+  if (this._index)
+    this._index.dispose()
+
   this._index = normalize(this.gl
     , attr
     , size


### PR DESCRIPTION
My code looked like this:

``` js
    var mesh = Geom(gl)
        .attr('position', complex)
        .faces(complex)
```

The second `faces` ends up creating a second element buffer, but the previous one is never disposed.

I've changed my code to just use only `attr('position')` although it's a bit confusing that way. 
