### PR TITLE
Allow to draw point lists

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ GLGeometry.prototype.bind = function bind(shader) {
 
 GLGeometry.prototype.draw = function draw(mode) {
   this.update()
-  if(mode === undefnied) {
+  if(mode === undefined) {
     mode = this.gl.TRIANGLES
   }
   this._vao.draw(mode, this._length)


### PR DESCRIPTION
`gl.POINTS` is equal to 0, therefore doing `gl.POINTS || gl.TRIANGLES` will always evaluate to `gl.TRIANGLES`. 
