### PR TITLE
Fix bug with first draw call

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,14 +98,14 @@ GLGeometry.prototype.bind = function bind(shader) {
   this.update()
   this._vao.bind()
 
-  if (!shader) return
-  shader.bind()
-
   if (!this._keys) return
   for (var i = 0; i < this._keys.length; i++) {
     var attr = shader.attributes[this._keys[i]]
     if (attr) attr.location = i
   }
+
+  if (!shader) return
+  shader.bind()
 }
 
 GLGeometry.prototype.draw = function draw(mode, start, stop) {


### PR DESCRIPTION
Attribute locations aren't correct on the first draw call, because
the shader is bound in `GLGeometry.prototype.bind` before they are
updated and `gl-shader` updates locations when it is bound. Binding the
shader after the attributes are updated fixes the problem.

This fixes issue stackgl/gl-shader#5.