### PR TITLE
Fix dispose() to clean up everything

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,9 @@ GLGeometry.prototype.dispose = function() {
   }
 
   this._attributes = []
+  this._keys = []
+  this._length = 0
+  this._dirty = true
 
   if (this._index) {
     this._index.dispose()


### PR DESCRIPTION
I had a bug by reusing a geometry instance. I use dispose and after this I add new attribute values. This caused the error `Attribute 0 is disabled. This has signficant performance penalty` and my mesh could not be rendered anymore. I noticed that the geometry still have my attribute keys stored and so the indecies of attribute value and key did not map any more. 

I also added other default values from the constructor which may be to disposed.