### PR TITLE
modified normalize to accept nested arrays where the nested array is typed

### DIFF
--- a/normalize.js
+++ b/normalize.js
@@ -15,6 +15,14 @@ function normalize(gl, attr, size, mode, type) {
     }
   }
 
+  // if we get a nested 2D array (with the second array being typed)
+  if (Array.isArray(attr) && ista(attr[0])) {
+    return {
+        buffer: createBuffer(gl, pack(attr, type), mode)
+      , length: ( attr.length * attr[0].length ) / size
+    }
+  }
+
   // if we get a 1D array
   if (Array.isArray(attr)) {
     return {


### PR DESCRIPTION
Hey Hugh! 

Thanks for creating this! I've been working with JS again and I'm running into a case that isn't working with gl-geometry and instead of writing my own, I would love to use stackgl and help its growth! 

I have an array [] of vec2 (Float32Array) from gl-matrix.js and I'd like to pass that to gl-geometry like so: 
```javascript
var geo = Geometry( gl );
var test = [];
var a = new Float32Array(2); a[0] = -10.0; a[1] = 0.0;
var b = new Float32Array(2); b[0] = 10.0; b[1] = 0.0;
geo.attr( 'aPosition', test, { size: 2 } );
```
Let me know if this is crazy or if I'm doing something wrong! Would love to do it the right way! 

Thanks from Japan! 
Reza