### PR TITLE
Express offset in bytes, as expected by drawElements

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ GLGeometry.prototype.draw = function draw(mode, start, stop) {
   this.update()
 
   if (this._vao._useElements) {
-    this.gl.drawElements(mode, stop - start, this._vao._elementsType, start)
+    this.gl.drawElements(mode, stop - start, this._vao._elementsType, start * 2) // "2" is sizeof(uint16)
   } else {
     this.gl.drawArrays(mode, start, stop - start)
   }


### PR DESCRIPTION
Hi Hugh,

thanks for this module; this is a great abstraction over raw buffers and VAOs.

I am opening this pull request so as to discuss a difficulty I encountered while explicitly setting the `start` and `stop` arguments of the `draw` function while using indexed elements.

My understanding is that the WebGL [`drawElements`](https://www.khronos.org/registry/webgl/specs/1.0/#5.14.11) rendering call expects its `count` parameter to be [expressed in vertices](http://stackoverflow.com/a/18476626/38096), while its `offset` [should be expressed in bytes](http://stackoverflow.com/a/10224200/38096).

If we consider the `start` and `stop` parameters to be expressed in vertices, then `offset` will not be proper when `start` is greater than zero. Hence my pull request.

Note that I fixed the index size to `2` since the index type is hardcoded to `uint16` when normalizing the index buffer; however it would be more future proof to use something along the line of `sizeof(this._vao._elementsType)`. I do not know of a module that would provide such a function, though.

Note also that this PR is breaking compatibility with existing code. But I suspect this is more of a bugfix since current behavior makes the `start` argument difficult to use properly, so most people probably used a `0` / default value for it anyway. In any case you are the judge of the proper version number increment.

Anyway, it would be a pleasure to discuss this and perform any adjustments you'd deem necessary for this PR to be merged.

Regards,
Olivier.