### PR TITLE
Fix order-dependent calls for faces() and attr()

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You can specify `opt.size` for the vertex size, defaults to 3.
 ### geom.faces(values[, opt]) ###
 
 Pass a simplicial complex's `cells` property here in any of the above formats
-to use it as your index when drawing the geometry. This can only be called after all of the `.attr` calls. For example:
+to use it as your index when drawing the geometry. For example:
 
 ``` javascript
 var createGeometry = require('gl-geometry')

--- a/index.js
+++ b/index.js
@@ -67,6 +67,12 @@ GLGeometry.prototype.faces = function faces(attr, opts) {
 }
 
 GLGeometry.prototype.attr = function attr(name, attr, opts) {
+
+  // If we get a simplicial complex
+  if (attr.cells && attr.positions) {
+    return this.attr(name, attr.positions).faces(attr.cells, opts)
+  }
+
   opts = opts || {}
   this._dirty = true
 
@@ -84,7 +90,6 @@ GLGeometry.prototype.attr = function attr(name, attr, opts) {
 
   var buffer = attribute.buffer
   var length = attribute.length
-  var index  = attribute.index
 
   this._keys.push(name)
   this._attributes.push({
@@ -92,18 +97,10 @@ GLGeometry.prototype.attr = function attr(name, attr, opts) {
     , buffer: buffer
   })
 
-  var isSimplicialComplex = Boolean(index)
-  var attrLength = isSimplicialComplex ? attr.positions.length : length
-
   if (first) {
-    this._attrLength = attrLength
+    this._attrLength = length
 
-    if (isSimplicialComplex) {
-      this._index = index
-      this._facesLength = length
-    }
-
-  } else if (this._attrLength != attrLength) {
+  } else if (this._attrLength != length) {
     throw new Error(
         'Unexpected discrepancy in attributes size (was ' + this_attrLength
       + ', now ' + attrLength+ ')'

--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ function GLGeometry(gl) {
   this._elementsBytes = 2
   this._attributes = []
   this._dirty = true
-  this._length = 0
+  this._attrLength = 0
+  this._facesLength = 0
   this._index = null
   this._vao = null
   this._keys = []
@@ -27,7 +28,8 @@ GLGeometry.prototype.dispose = function() {
 
   this._attributes = []
   this._keys = []
-  this._length = 0
+  this._attrLength = 0  // Length of this attribute (the number of vertices it feeds)
+  this._facesLength = 0 // Number of vertices needed to draw all faces
   this._dirty = true
 
   if (this._index) {
@@ -58,7 +60,7 @@ GLGeometry.prototype.faces = function faces(attr, opts) {
     , 'uint16'
   )
 
-  this._length = this._index.length * size
+  this._facesLength = this._index.length * size
   this._index = this._index.buffer
 
   return this
@@ -90,12 +92,22 @@ GLGeometry.prototype.attr = function attr(name, attr, opts) {
     , buffer: buffer
   })
 
-  if (first) {
-    this._length = length
-  }
+  var isSimplicialComplex = Boolean(index)
+  var attrLength = isSimplicialComplex ? attr.positions.length : length
 
-  if (first && index) {
-    this._index = index
+  if (first) {
+    this._attrLength = attrLength
+
+    if (isSimplicialComplex) {
+      this._index = index
+      this._facesLength = length
+    }
+
+  } else if (this._attrLength != attrLength) {
+    throw new Error(
+        'Unexpected discrepancy in attributes size (was ' + this_attrLength
+      + ', now ' + attrLength+ ')'
+    )
   }
 
   return this
@@ -117,14 +129,15 @@ GLGeometry.prototype.bind = function bind(shader) {
 
 GLGeometry.prototype.draw = function draw(mode, start, stop) {
   start = typeof start === 'undefined' ? 0 : start
-  stop  = typeof stop  === 'undefined' ? this._length : stop
   mode  = typeof mode  === 'undefined' ? this.gl.TRIANGLES : mode
 
   this.update()
 
   if (this._vao._useElements) {
-    this.gl.drawElements(mode, stop - start, this._elementsType, start * this._elementsBytes) // "2" is sizeof(uint16)
+    stop  = typeof stop  === 'undefined' ? this._facesLength : stop
+    this.gl.drawElements(mode, stop - start, this._elementsType, start * this._elementsBytes)
   } else {
+    stop  = typeof stop  === 'undefined' ? this._attrLength : stop
     this.gl.drawArrays(mode, start, stop - start)
   }
 }

--- a/normalize.js
+++ b/normalize.js
@@ -39,18 +39,6 @@ function normalize(gl, attr, size, mode, type) {
     }
   }
 
-  // if we get a simplicial complex
-  if (attr.cells && attr.positions) {
-    return {
-        length: attr.cells.length * size
-      , buffer: createBuffer(gl, pack(attr.positions, type), mode)
-      , index : createBuffer(gl
-        , pack(attr.cells, 'uint16')
-        , gl.ELEMENT_ARRAY_BUFFER
-      )
-    }
-  }
-
   // if we get an ndarray
   if (isnd(attr)) {
     return {

--- a/test.js
+++ b/test.js
@@ -21,25 +21,28 @@ var clear         = require('gl-clear')({
 // handles simplicial complexes with cells/positions properties
 var scPos = bunny
 var scNor = normals.vertexNormals(bunny.cells, bunny.positions)
-createExample(scPos, scNor)
+createExample(scPos, scNor).title = 'Simplicial Complex'
 
 // handles Float32Arrays
 var uiPos = unindex(bunny.positions, bunny.cells)
 var uiNor = faceNormals(uiPos)
-createExample(uiPos, uiNor)
+createExample(uiPos, uiNor).title = 'Unindexed Mesh, Float32Arrays'
 
 // handles (flat) ndarrays
 var ndPos = ndarray(uiPos, [uiPos.length])
 var ndNor = ndarray(uiNor, [uiNor.length])
-createExample(ndPos, ndNor)
+createExample(ndPos, ndNor).title = 'Flat ndarrays'
 
 // also supports .faces() method
-createExample(scPos.positions, scNor, scPos.cells)
+createExample(scPos.positions, scNor, scPos.cells).title = '.faces(), Last Call'
 
 // also supports .faces() method with packed data
-createExample(pack(scPos.positions), scNor, pack(scPos.cells))
+createExample(pack(scPos.positions), scNor, pack(scPos.cells)).title = '.faces(), Packed Data'
 
-function createExample(pos, norm, cells) {
+// .faces(), order-independant
+createExample(scPos.positions, scNor, scPos.cells, true).title = '.faces(), First Call'
+
+function createExample(pos, norm, cells, facesFirst) {
   var canvas     = document.body.appendChild(document.createElement('canvas'))
   var gl         = createContext(canvas, render)
   var camera     = createCamera(canvas)
@@ -54,10 +57,12 @@ function createExample(pos, norm, cells) {
   canvas.style.margin = '1em'
 
   var geom = createGeom(gl)
-    .attr('position', pos)
+  if (cells && facesFirst) geom.faces(cells)
+  
+  geom.attr('position', pos)
     .attr('normal', norm)
 
-  if (cells) geom.faces(cells)
+  if (cells && !facesFirst) geom.faces(cells)
 
   function render() {
     var width  = canvas.width
@@ -84,4 +89,6 @@ function createExample(pos, norm, cells) {
 
     camera.tick()
   }
+  
+  return canvas
 }


### PR DESCRIPTION
While considering https://github.com/hughsk/gl-geometry/issues/14, I noticed that @TatumCreative encountered rendering artifacts while calling `faces()` before `attr()`. He accordingly added a note in `README.md` warning that `faces()` should be called last.

He was kind enough to provide me with a way to reproduce the issue (running [example 3](https://github.com/glamjs/glam/blob/master/examples/03-normal-colors/normal-colors.js) from [`glam`](https://github.com/glamjs/glam) while swapping calls in [this file](https://github.com/glamjs/glam/blob/f5e5ec51c0475fcae6736de4961402d9d351a147/lib/material/lit/lit-set-attributes.js)), so I studied this in more details.

It appears the issue was due to an ambiguity in the use of `_length`. Indeed it was both used to store faces and attributes size, which led to feeding the draw call with an improper value when calling `faces()` before any `attr()`. Hence the artifacts.

This PR provides a fix to this behavior by using distinct fields for both kinds of length, and building draw call parameters accordingly.

I also took the liberty of:
* adding a test case for "`faces()` first" in `test.js`,
* naming existing test cases (using HTML `title`),
* simplifying simplicial complex processing by moving it from `normalize.js` to `index.js`,
* adding a sanity check at the end of `attr()` to ensure that all attributes have the same length.

I feel the last one is a good practice, but I may have missed a situation where different-length attributes would be legit when using `gl-geometry`. Please, let's discuss this if you reckon such a case is possible.

That last point excepted, I believe this PR does not break compatibility with existing code. So, should it be merged, I'd suggest a patch-level increment for `gl-geometry` version number.

This code was tested with `gl-geometry` test cases, the aforementioned `glam` example and `bunny-walkthrough`.

Regards,
Olivier.