### PR TITLE
Implemented support for 1 and 4 byte element types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ var geom = createGeometry(gl)
 
 You can specify `opt.size` for the cell size, defaults to 3.
 
+You can specify `opt.elementsBytes` for the element byte size, defaults to 2.
+Can be 1 or 2. If the context is a WebGL 2 context or the extension
+`OES_element_index_uint` is enabled in a WebGL 1 context, opt.elementsBytes
+may additionally be 4.
+
 ### geom.bind([shader]) ###
 
 Binds the underlying [VAO](https://github.com/stackgl/gl-vao) – this must

--- a/index.js
+++ b/index.js
@@ -46,6 +46,7 @@ GLGeometry.prototype.dispose = function () {
 
 GLGeometry.prototype.faces = function faces (attr, opts) {
   var size = opts && opts.size || 3
+  var elementsBytes = opts && opts.elementsBytes || 2
   attr = attr.cells ? attr.cells : attr
 
   this._dirty = true
@@ -54,13 +55,27 @@ GLGeometry.prototype.faces = function faces (attr, opts) {
     this._index.dispose()
   }
 
+  if ( elementsBytes == 1 )
+  {
+      this._elementsType = this.gl.UNSIGNED_BYTE
+  }
+  else if ( elementsBytes == 2 )
+  {
+      this._elementsType = this.gl.UNSIGNED_SHORT
+  }
+  else if ( elementsBytes == 4 )
+  {
+      this._elementsType = this.gl.UNSIGNED_INT
+  }
+
   this._index = normalize.create(this.gl
     , attr
     , size
     , this.gl.ELEMENT_ARRAY_BUFFER
-    , 'uint16'
+    , glType(this._elementsType)
   )
 
+  this._elementsBytes = elementsBytes;
   this._facesLength = this._index.length * size
   this._index = this._index.buffer
 
@@ -155,7 +170,7 @@ GLGeometry.prototype.update = function update () {
   this._dirty = false
   if (this._vao) this._vao.dispose()
 
-  this._vao = createVAO(this.gl, this._attributes, this._index)
+  this._vao = createVAO(this.gl, this._attributes, this._index, this._elementsType)
   this._elementsType = this._vao._elementsType
   this._elementsBytes = dtype(
     glType(this._elementsType) || 'array'


### PR DESCRIPTION
Support for element array buffers of type gl.UNSIGNED_BYTE and gl.UNSIGNED_INT in addition to the default gl.UNSIGNED_SHORT.